### PR TITLE
Setting workflows to run every 12 hours

### DIFF
--- a/.github/workflows/e2ev2-matrix.yaml
+++ b/.github/workflows/e2ev2-matrix.yaml
@@ -1,6 +1,8 @@
 name: E2E Version 2 Test Matrix
 
 on:
+  schedule:
+    - cron: '0 */12 * * *'
   workflow_call:
     inputs:
       ref:


### PR DESCRIPTION
The e2ev2-matrix.yaml workflow calls the e2ev2-provision-test.yaml. Setting the on.schedule.cron property should run e2e tests every 12 hours