### PR TITLE
Main branch temporarily set to run workflows every 5 mins

### DIFF
--- a/.github/workflows/e2ev2-matrix.yaml
+++ b/.github/workflows/e2ev2-matrix.yaml
@@ -1,6 +1,8 @@
 name: E2E Version 2 Test Matrix
 
 on:
+  schedule:
+    - cron: '0 */12 * * *'
   workflow_call:
     inputs:
       ref:


### PR DESCRIPTION
Main branch had an issue with ref in GH workflow, testing to see if it runs every 5 mins passing plan-infra step successfully before changing it back to 12 hours