### PR TITLE
Updated GH actions to use node20

### DIFF
--- a/.github/workflows/e2ev2-matrix.yaml
+++ b/.github/workflows/e2ev2-matrix.yaml
@@ -38,7 +38,7 @@ jobs:
             inputs.skipRefCheck
 
       - name: Ensure ref
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ !((github.event_name == 'repository_dispatch' && github.event.client_payload.slash_command.args.named.sha != '' && contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.args.named.sha)) || inputs.skipRefCheck) }}
         with:
             script: core.setFailed('Ref is not latest')

--- a/.github/workflows/e2ev2-matrix.yaml
+++ b/.github/workflows/e2ev2-matrix.yaml
@@ -18,11 +18,11 @@ jobs:
     outputs:
        matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '~1.20.3'
           cache-dependency-path: "**/*.sum"

--- a/.github/workflows/e2ev2-provision-test.yaml
+++ b/.github/workflows/e2ev2-provision-test.yaml
@@ -29,7 +29,7 @@ jobs:
           cache-dependency-path: "**/*.sum"
 
       - name: Azure login
-        uses: azure/login@v1
+        uses: azure/login@v1.6.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -56,7 +56,7 @@ jobs:
           script: core.setFailed('Ref is not latest')
 
       - name: Upload infra file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: infra
           path: infrafolder/infra.json
@@ -64,11 +64,11 @@ jobs:
     needs: provision
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '~1.20.3'
 

--- a/.github/workflows/e2ev2-provision-test.yaml
+++ b/.github/workflows/e2ev2-provision-test.yaml
@@ -19,11 +19,11 @@ jobs:
   provision:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '~1.20.3'
           cache-dependency-path: "**/*.sum"
@@ -50,13 +50,13 @@ jobs:
           inputs.skipRefCheck
 
       - name: Ensure ref
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ !((github.event_name == 'repository_dispatch' && github.event.client_payload.slash_command.args.named.sha != '' && contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.args.named.sha)) || inputs.skipRefCheck) }}
         with:
           script: core.setFailed('Ref is not latest')
 
       - name: Upload infra file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: infra
           path: infrafolder/infra.json
@@ -73,7 +73,7 @@ jobs:
           go-version: '~1.20.3'
 
       - name: Azure login
-        uses: azure/login@v1
+        uses: azure/login@v1.6.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -95,7 +95,7 @@ jobs:
           inputs.skipRefCheck
 
       - name: Ensure ref
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ !((github.event_name == 'repository_dispatch' && github.event.client_payload.slash_command.args.named.sha != '' && contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.args.named.sha)) || inputs.skipRefCheck) }}
         with:
           script: core.setFailed('Ref is not latest')

--- a/.github/workflows/pr-validate-fork.yaml
+++ b/.github/workflows/pr-validate-fork.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: set-check-run-in-progress
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: set-check-run-in-progress
         env:
           number: ${{ github.event.client_payload.pull_request.number }}

--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: update-check-run
         env:
           number: ${{ github.event.number }}


### PR DESCRIPTION
Many actions used in workflows are using Node16, this PR updates the versions of most of those actions.  **There are still warnings in the workflow runs.**

Azure/login is at 1.6.1 and has not yet merged a version which uses Node 20 to master. Updating upload-artifact and download-artifact to v4 breaks the workflows, and they must use the same versions, so their versions are v3.